### PR TITLE
Fix unsaved changes prompt not firing

### DIFF
--- a/views/buttons.php
+++ b/views/buttons.php
@@ -35,7 +35,7 @@ $().ready(function() {
             <?php else: ?>
             return val + php_left + php_start + space + include_start + snippet + include_end + space + php_end + '\n';
             <?php endif; ?>
-        });
+        }).change();
 	return false
     };
 

--- a/views/select.php
+++ b/views/select.php
@@ -42,7 +42,7 @@ $().ready(function() {
             <?php else: ?>
             return val + php_left + php_start + space + include_start + snippet + include_end + space + php_end + '\n';
             <?php endif; ?>
-        });
+        }).change();
 	return false
     };
 


### PR DESCRIPTION
I have no idea why the `change()` event is firing from one button but not the other,
but I suspect is has something to do with the way `<form>` elements are processed
by the browser.

Anyways, if you just fire it at the right position in sequence, that problem from #6 goes away.
